### PR TITLE
URL Cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # RabbitMQ Signing Keys
 
 This repository contains an alternative download location for the public keys
-that can be used to [verify signatures of RabbitMQ release artifacts](http://www.rabbitmq.com/signatures.html).
+that can be used to [verify signatures of RabbitMQ release artifacts](https://www.rabbitmq.com/signatures.html).
 
 Please see [Releases](https://github.com/rabbitmq/signing-keys/releases).


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* http://www.rabbitmq.com/signatures.html with 1 occurrences migrated to:  
  https://www.rabbitmq.com/signatures.html ([https](https://www.rabbitmq.com/signatures.html) result 200).